### PR TITLE
fix: increase app icon size in onboarding step 3

### DIFF
--- a/Focca/Views/Onboarding/OnboardingStep3.swift
+++ b/Focca/Views/Onboarding/OnboardingStep3.swift
@@ -175,7 +175,8 @@ struct AppRow: View {
         HStack(spacing: 16) {
             Label(appInfo.token)
                 .labelStyle(.iconOnly)
-                .font(.system(size: 56))
+                .frame(width: 96, height: 96)
+                .scaleEffect(1.7)
                 .frame(width: 64, height: 64)
                 .background(Color.white)
                 .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))


### PR DESCRIPTION
Dois dias tentando, 1 linha resolvia, mas foi haha

  - Force larger frame (96x96) for better native rendering
  - Apply scaleEffect(1.7) to enlarge icon display
  - Maintain 64x64 container size for layout consistency
  - Remove unused .font() modifier

  Fixes #2
  
  
<img width="428" height="892" alt="image" src="https://github.com/user-attachments/assets/34266055-18a1-4f2e-9cba-85d2f8cea218" />
