### PR TITLE
fix: Enable category selection in FamilyActivityPicker

### DIFF
--- a/Focca/ContentView.swift
+++ b/Focca/ContentView.swift
@@ -1,10 +1,3 @@
-//
-//  ContentView.swift
-//  Focca
-//
-//  Created by Fiasco on 27/10/25.
-//
-
 import SwiftUI
 
 struct ContentView: View {
@@ -25,19 +18,22 @@ struct ContentView: View {
                     OnboardingStep4()
                         .navigationBarHidden(true)
                 }
-            } else {
-                // Sempre mostra o onboarding quando autenticado
+            } else if !hasCompletedOnboardingForCurrentUser {
                 NavigationView {
                     OnboardingStep1()
                         .navigationBarHidden(true)
                 }
+            } else {
+                PrincipalView()
             }
         }
-        .onAppear {
-            // Limpa o estado de onboarding para forçar sempre mostrar
-            UserDefaults.standard.set(false, forKey: "hasCompletedOnboarding")
-            UserDefaults.standard.removeObject(forKey: "onboarding_completed_email")
+    }
+    
+    private var hasCompletedOnboardingForCurrentUser: Bool {
+        guard let email = authViewModel.currentEmail else {
+            return false
         }
+        return hasCompletedOnboarding && onboardingCompletedEmail == email
     }
 }
 

--- a/Focca/ContentView.swift
+++ b/Focca/ContentView.swift
@@ -25,22 +25,19 @@ struct ContentView: View {
                     OnboardingStep4()
                         .navigationBarHidden(true)
                 }
-            } else if !hasCompletedOnboardingForCurrentUser {
+            } else {
+                // Sempre mostra o onboarding quando autenticado
                 NavigationView {
                     OnboardingStep1()
                         .navigationBarHidden(true)
                 }
-            } else {
-                PrincipalView()
             }
         }
-    }
-    
-    private var hasCompletedOnboardingForCurrentUser: Bool {
-        guard let email = authViewModel.currentEmail else {
-            return false
+        .onAppear {
+            // Limpa o estado de onboarding para forçar sempre mostrar
+            UserDefaults.standard.set(false, forKey: "hasCompletedOnboarding")
+            UserDefaults.standard.removeObject(forKey: "onboarding_completed_email")
         }
-        return hasCompletedOnboarding && onboardingCompletedEmail == email
     }
 }
 

--- a/Focca/Views/BlockedView.swift
+++ b/Focca/Views/BlockedView.swift
@@ -86,9 +86,11 @@ struct BlockedView: View {
                         // Finaliza TODAS as sessões ativas do dia atual para garantir que não continue contando
                         AppBlockingTracker.shared.endAllActiveSessions(for: Date(), endDate: Date())
                         
-                        // Desbloqueia os apps
+                        // Desbloqueia apps, categorias e sites
                         let store = ManagedSettingsStore()
                         store.application.blockedApplications = nil
+                        store.shield.applicationCategories = nil
+                        store.webContent.blockedByFilter = nil
 
                         if let startDate = sharedDefaults.object(forKey: "blocked_start_date") as? Date {
                             TimerStorage.shared.splitOvernightTime(from: startDate, to: Date())

--- a/Focca/Views/Modes/AppIconGrid.swift
+++ b/Focca/Views/Modes/AppIconGrid.swift
@@ -1,20 +1,29 @@
 import SwiftUI
 import FamilyControls
+import ManagedSettings
 
 struct AppIconGrid: View {
     let selection: FamilyActivitySelection
     let onTap: () -> Void
     
+    private var totalItems: Int {
+        selection.applicationTokens.count + selection.categoryTokens.count + selection.webDomainTokens.count
+    }
+    
+    private var hasSelection: Bool {
+        totalItems > 0
+    }
+    
     var body: some View {
         Button(action: onTap) {
             VStack(spacing: 0) {
                 HStack {
-                    Text(selection.applicationTokens.count > 0 ? "Apps selecionados" : "Selecionar apps")
+                    Text(hasSelection ? "Apps selecionados" : "Selecionar apps")
                         .font(.system(size: 16, weight: .medium))
                         .foregroundColor(Color(hex: "1C1C1E"))
                     Spacer()
-                    if selection.applicationTokens.count > 0 {
-                        Text("\(selection.applicationTokens.count)/50")
+                    if hasSelection {
+                        Text("\(totalItems)/50")
                             .font(.system(size: 16, weight: .medium))
                             .foregroundColor(Color(hex: "1C1C1E"))
                     } else {
@@ -30,12 +39,36 @@ struct AppIconGrid: View {
                     columns: Array(repeating: GridItem(.flexible(), spacing: 0), count: 8),
                     spacing: 12
                 ) {
-                    if selection.applicationTokens.count > 0 {
-                        ForEach(Array(selection.applicationTokens.prefix(16)), id: \.hashValue) { token in
+                    if hasSelection {
+                        // Combina apps e categorias, limitando a 16 itens no total
+                        let appTokens = Array(selection.applicationTokens)
+                        let categoryTokens = Array(selection.categoryTokens)
+                        let maxApps = min(appTokens.count, 16)
+                        let remainingSlots = max(0, 16 - maxApps)
+                        let maxCategories = min(categoryTokens.count, remainingSlots)
+                        
+                        // Mostra apps primeiro (até 16)
+                        ForEach(Array(appTokens.prefix(maxApps)), id: \.hashValue) { token in
                             Label(token)
                                 .labelStyle(.iconOnly)
                                 .font(.system(size: 42))
                                 .scaleEffect(1.6)
+                        }
+                        
+                        // Mostra categorias depois (preenchendo os slots restantes até 16 total)
+                        ForEach(Array(categoryTokens.prefix(maxCategories)), id: \.hashValue) { token in
+                            Label(token)
+                                .labelStyle(.iconOnly)
+                                .font(.system(size: 42))
+                                .scaleEffect(1.6)
+                        }
+                        
+                        // Preenche espaços vazios se houver menos de 16 itens
+                        let totalDisplayed = maxApps + maxCategories
+                        let emptySlots = max(0, 16 - totalDisplayed)
+                        ForEach(0..<emptySlots, id: \.self) { _ in
+                            Color.clear
+                                .frame(width: 42, height: 42)
                         }
                     } else {
                         ForEach(0..<16, id: \.self) { _ in
@@ -58,6 +91,7 @@ struct AppIconGrid: View {
         )
     }
 }
+
 
 #Preview {
     let selection = FamilyActivitySelection()

--- a/Focca/Views/Modes/AppIconGrid.swift
+++ b/Focca/Views/Modes/AppIconGrid.swift
@@ -29,7 +29,7 @@ struct AppIconGrid: View {
                     } else {
                         Image(systemName: "chevron.right")
                             .font(.system(size: 14, weight: .medium))
-                            .foregroundColor(Color(hex: "C6C6C8"))
+                            .foregroundColor(Color.black.opacity(0.3))
                     }
                 }
                 .padding(.horizontal, 20)
@@ -49,18 +49,24 @@ struct AppIconGrid: View {
                         
                         // Mostra apps primeiro (até 16)
                         ForEach(Array(appTokens.prefix(maxApps)), id: \.hashValue) { token in
-                            Label(token)
-                                .labelStyle(.iconOnly)
-                                .font(.system(size: 42))
-                                .scaleEffect(1.6)
+                            ZStack {
+                                Color.clear
+                                Label(token)
+                                    .labelStyle(.iconOnly)
+                                    .font(.system(size: 42))
+                                    .scaleEffect(1.6)
+                            }
                         }
                         
                         // Mostra categorias depois (preenchendo os slots restantes até 16 total)
                         ForEach(Array(categoryTokens.prefix(maxCategories)), id: \.hashValue) { token in
-                            Label(token)
-                                .labelStyle(.iconOnly)
-                                .font(.system(size: 42))
-                                .scaleEffect(1.6)
+                            ZStack {
+                                Color.clear
+                                Label(token)
+                                    .labelStyle(.iconOnly)
+                                    .font(.system(size: 42))
+                                    .scaleEffect(1.6)
+                            }
                         }
                         
                         // Preenche espaços vazios se houver menos de 16 itens
@@ -74,7 +80,7 @@ struct AppIconGrid: View {
                         ForEach(0..<16, id: \.self) { _ in
                             Image(systemName: "app.fill")
                                 .font(.system(size: 42))
-                                .foregroundColor(Color(hex: "C6C6C8"))
+                                .foregroundColor(Color.black.opacity(0.1))
                         }
                     }
                 }

--- a/Focca/Views/Modes/CreateModeView.swift
+++ b/Focca/Views/Modes/CreateModeView.swift
@@ -245,7 +245,7 @@ struct CreateModeView: View {
                         .foregroundColor(canSave ? Color(hex: "1C1C1E") : Color(hex: "9E9EA3"))
                         .frame(maxWidth: .infinity)
                         .frame(height: 56)
-                        .background(canSave ? Color(hex: "DAD7D6") : Color(hex: "D0D0D0"))
+                        .background(canSave ? Color.black.opacity(0.15) : Color.black.opacity(0.1))
                         .cornerRadius(14)
                 }
                 .disabled(!canSave)

--- a/Focca/Views/Modes/CreateModeView.swift
+++ b/Focca/Views/Modes/CreateModeView.swift
@@ -16,7 +16,8 @@ struct CreateModeView: View {
     // Feature 1: Valida se schedule está ativo, deve ter pelo menos 1 dia selecionado
     // Feature 4: Valida se não há conflito com schedules existentes
     private var canSave: Bool {
-        let basicValidation = modeName.count >= 4 && modeName.count <= 18 && selection.applicationTokens.count > 0
+        let totalItems = selection.applicationTokens.count + selection.categoryTokens.count + selection.webDomainTokens.count
+        let basicValidation = modeName.count >= 4 && modeName.count <= 18 && totalItems > 0
         let scheduleValidation = !isScheduled || (selectedWeekdays.count >= 1 && scheduleDurationIsValid)
         let noConflict = !hasScheduleConflict()
         return basicValidation && scheduleValidation && noConflict

--- a/Focca/Views/Modes/CreateModeView.swift
+++ b/Focca/Views/Modes/CreateModeView.swift
@@ -277,7 +277,8 @@ struct CreateModeView: View {
             UserDefaults.standard.set(Date(), forKey: "mode_\(modeName)_last_used")
             
             UserDefaults.standard.set(modeName, forKey: "active_mode_name")
-            UserDefaults.standard.set(selection.applicationTokens.count, forKey: "active_mode_app_count")
+            let totalCount = selection.applicationTokens.count + selection.categoryTokens.count + selection.webDomainTokens.count
+            UserDefaults.standard.set(totalCount, forKey: "active_mode_app_count")
             
             // Salva o schedule se ativado
             if isScheduled && selectedWeekdays.count >= 1 {

--- a/Focca/Views/Modes/EditModeView.swift
+++ b/Focca/Views/Modes/EditModeView.swift
@@ -30,8 +30,9 @@ struct EditModeView: View {
             return false
         }
         
-        // Validação básica da seleção de apps
-        guard selection.applicationTokens.count > 0 else {
+        // Validação básica da seleção (apps, categorias ou sites)
+        let totalItems = selection.applicationTokens.count + selection.categoryTokens.count + selection.webDomainTokens.count
+        guard totalItems > 0 else {
             return false
         }
         

--- a/Focca/Views/Modes/EditModeView.swift
+++ b/Focca/Views/Modes/EditModeView.swift
@@ -529,8 +529,9 @@ struct EditModeView: View {
         // Atualiza o contador de apps se este modo estiver ativo
         let activeModeName = UserDefaults.standard.string(forKey: "active_mode_name")
         if activeModeName == finalModeName {
-            UserDefaults.standard.set(selection.applicationTokens.count, forKey: "active_mode_app_count")
-            print("✅ [EditModeView] Atualizado contador de apps para modo ativo: \(selection.applicationTokens.count) apps")
+            let totalCount = selection.applicationTokens.count + selection.categoryTokens.count + selection.webDomainTokens.count
+            UserDefaults.standard.set(totalCount, forKey: "active_mode_app_count")
+            print("✅ [EditModeView] Atualizado contador para modo ativo: \(totalCount) items (\(selection.applicationTokens.count) apps, \(selection.categoryTokens.count) categorias, \(selection.webDomainTokens.count) sites)")
         }
 
         return true

--- a/Focca/Views/Modes/EditModeView.swift
+++ b/Focca/Views/Modes/EditModeView.swift
@@ -302,7 +302,7 @@ struct EditModeView: View {
                             .foregroundColor(canSave ? .white : Color(hex: "9E9EA3"))
                             .frame(maxWidth: .infinity)
                             .frame(height: 56)
-                            .background(canSave ? Color(hex: "2C2C2E") : Color(hex: "EDEBEA"))
+                            .background(canSave ? Color(hex: "2C2C2E") : Color.black.opacity(0.1))
                             .cornerRadius(14)
                     }
                     .disabled(!canSave)
@@ -314,7 +314,7 @@ struct EditModeView: View {
                             .font(.system(size: 16, weight: .medium))
                             .foregroundColor(canDelete ? .white : Color(hex: "9E9EA3"))
                             .frame(width: 56, height: 56)
-                            .background(canDelete ? Color.red : Color(hex: "EDEBEA"))
+                            .background(canDelete ? Color.red : Color.black.opacity(0.1))
                             .cornerRadius(14)
                     }
                     .disabled(!canDelete)

--- a/Focca/Views/Modes/ModeSelectionSheet.swift
+++ b/Focca/Views/Modes/ModeSelectionSheet.swift
@@ -179,7 +179,8 @@ struct ModeSelectionSheet: View {
         
         if let data = UserDefaults.standard.data(forKey: "mode_\(modeName)_selection"),
            let saved = try? JSONDecoder().decode(FamilyActivitySelection.self, from: data) {
-            UserDefaults.standard.set(saved.applicationTokens.count, forKey: "active_mode_app_count")
+            let totalCount = saved.applicationTokens.count + saved.categoryTokens.count + saved.webDomainTokens.count
+            UserDefaults.standard.set(totalCount, forKey: "active_mode_app_count")
             
             let encoded = try? JSONEncoder().encode(saved)
             UserDefaults.standard.set(encoded, forKey: "familyActivitySelection")

--- a/Focca/Views/Onboarding/OnboardingStep2.swift
+++ b/Focca/Views/Onboarding/OnboardingStep2.swift
@@ -23,51 +23,51 @@ struct OnboardingStep2: View {
                     
                     HStack(spacing: 12) {
                         VStack(alignment: .leading, spacing: 4) {
-                            if selection.applicationTokens.count > 0 {
-                                Text("\(selection.applicationTokens.count)/50 apps selecionados")
-                                    .font(.system(size: 14))
-                                    .foregroundColor(.secondary)
-                                if selection.applicationTokens.count > 50 {
-                                    Text("⚠️ Máximo de 50 apps permitidos")
-                                        .font(.system(size: 11))
-                                        .foregroundColor(.orange)
+                            let totalItems = selection.applicationTokens.count + selection.categoryTokens.count + selection.webDomainTokens.count
+
+                            if totalItems > 0 {
+                                if selection.categoryTokens.count > 0 {
+                                    Text("\(selection.categoryTokens.count) categoria(s) selecionada(s)")
+                                        .font(.system(size: 14))
+                                        .foregroundColor(.secondary)
                                 }
-                            } else if selection.categoryTokens.count > 0 {
-                                Text("0/50 apps selecionados")
-                                    .font(.system(size: 14))
-                                    .foregroundColor(.secondary)
-                                Text("⚠️ Remova a categoria e escolha os apps individualmente")
-                                    .font(.system(size: 11))
-                                    .foregroundColor(.orange)
+                                if selection.applicationTokens.count > 0 {
+                                    Text("\(selection.applicationTokens.count) app(s) selecionado(s)")
+                                        .font(.system(size: 14))
+                                        .foregroundColor(.secondary)
+                                }
+                                if selection.webDomainTokens.count > 0 {
+                                    Text("\(selection.webDomainTokens.count) site(s) selecionado(s)")
+                                        .font(.system(size: 14))
+                                        .foregroundColor(.secondary)
+                                }
                             } else {
-                                Text("0/50 apps selecionados")
+                                Text("Nenhuma seleção")
                                     .font(.system(size: 14))
                                     .foregroundColor(.secondary)
                             }
                         }
-                        
+
                         Spacer()
-                        
+
                         Button(action: {
-                            if selection.applicationTokens.count <= 50 {
-                                // Verifica se a permissão de Screen Time foi concedida
-                                if isAuthorized {
-                                    saveSelection()
-                                    didComplete()
-                                } else {
-                                    showAuthorizationAlert = true
-                                }
+                            // Verifica se a permissão de Screen Time foi concedida
+                            if isAuthorized {
+                                saveSelection()
+                                didComplete()
+                            } else {
+                                showAuthorizationAlert = true
                             }
                         }) {
                             Text("Continuar")
                                 .fontWeight(.semibold)
-                                .foregroundColor((selection.applicationTokens.count > 50 || !isAuthorized) ? Color(hex: "9E9EA3") : .white)
+                                .foregroundColor(!isAuthorized ? Color(hex: "9E9EA3") : .white)
                                 .padding(.horizontal, 24)
                                 .frame(height: 40)
-                                .background((selection.applicationTokens.count > 50 || !isAuthorized) ? Color(hex: "DAD7D6") : Color.black)
+                                .background(!isAuthorized ? Color(hex: "DAD7D6") : Color.black)
                                 .cornerRadius(20)
                         }
-                        .disabled(selection.applicationTokens.count > 50 || !isAuthorized)
+                        .disabled(!isAuthorized)
                     }
                     .padding(.horizontal, 20)
                     .padding(.bottom, 10)

--- a/Focca/Views/Onboarding/OnboardingStep2.swift
+++ b/Focca/Views/Onboarding/OnboardingStep2.swift
@@ -64,7 +64,7 @@ struct OnboardingStep2: View {
                                 .foregroundColor(!isAuthorized ? Color(hex: "9E9EA3") : .white)
                                 .padding(.horizontal, 24)
                                 .frame(height: 40)
-                                .background(!isAuthorized ? Color(hex: "DAD7D6") : Color.black)
+                                .background(!isAuthorized ? Color.black.opacity(0.15) : Color.black)
                                 .cornerRadius(20)
                         }
                         .disabled(!isAuthorized)

--- a/Focca/Views/Onboarding/OnboardingStep3.swift
+++ b/Focca/Views/Onboarding/OnboardingStep3.swift
@@ -6,7 +6,7 @@ import DeviceActivity
 @available(iOS 17.0, *)
 struct OnboardingStep3: View {
     @StateObject var model = SelectionModel()
-    @State private var appInfos: [AppInfo] = []
+    @State private var appInfos: [SelectionItem] = []
     @State private var isLoading = true
     @State private var showLoginView = false
     @State private var showStep2 = false
@@ -50,9 +50,14 @@ struct OnboardingStep3: View {
                     } else {
                         ScrollView {
                             VStack(spacing: 0) {
-                                ForEach(appInfos) { app in
-                                    AppRow(appInfo: app)
-                                    if app.id != appInfos.last?.id {
+                                ForEach(appInfos) { item in
+                                    switch item {
+                                    case .app(let appInfo):
+                                        AppRow(appInfo: appInfo)
+                                    case .category(let categoryInfo):
+                                        CategoryRow(categoryInfo: categoryInfo)
+                                    }
+                                    if item.id != appInfos.last?.id {
                                         Divider().padding(.leading, 62)
                                     }
                                 }
@@ -66,9 +71,10 @@ struct OnboardingStep3: View {
 
                     VStack(spacing: 16) {
                         Button(action: {
-                            if appInfos.count > 50 {
+                            let totalItems = model.selection.applicationTokens.count + model.selection.categoryTokens.count + model.selection.webDomainTokens.count
+                            if totalItems > 50 {
                                 showAlert = true
-                            } else if model.selection.applicationTokens.count > 0 && model.selection.applicationTokens.count <= 50 {
+                            } else if totalItems > 0 && totalItems <= 50 {
                                 Task {
                                     await requestNotificationPermission()
                                 }
@@ -117,13 +123,13 @@ struct OnboardingStep3: View {
                     Task { await refreshSelectionAndApps() }
                 })
             }
-            .alert("Muitos apps selecionados", isPresented: $showAlert) {
+            .alert("Muitos itens selecionados", isPresented: $showAlert) {
                 Button("Editar apps", action: {
                     showStep2 = true
                 })
                 Button("OK", role: .cancel) { }
             } message: {
-                Text("Você só pode bloquear até 50 apps. Remova alguns para continuar.")
+                Text("Você só pode bloquear até 50 itens (apps, categorias ou sites). Remova alguns para continuar.")
             }
             .task {
                 if let data = UserDefaults.standard.data(forKey: "familyActivitySelection"),
@@ -155,24 +161,37 @@ struct OnboardingStep3: View {
     }
 
     @available(iOS 17.0, *)
-    func fetchAppInfo(from selection: FamilyActivitySelection) async -> [AppInfo] {
-        var infos: [AppInfo] = []
+    func fetchAppInfo(from selection: FamilyActivitySelection) async -> [SelectionItem] {
+        var items: [SelectionItem] = []
 
+        // Adiciona apps
         for token in selection.applicationTokens {
             let app = Application(token: token)
             let name = app.localizedDisplayName ?? "Unknown App"
             let icon = UIImage(systemName: "app.fill")!
 
-            infos.append(AppInfo(
+            items.append(.app(AppInfo(
                 id: token.hashValue.description,
                 name: name,
                 icon: icon,
                 color: .clear,
                 token: token
-            ))
+            )))
+        }
+        
+        // Adiciona categorias
+        for token in selection.categoryTokens {
+            let category = ActivityCategory(token: token)
+            let name = category.localizedDisplayName ?? "Categoria"
+            
+            items.append(.category(CategoryInfo(
+                id: token.hashValue.description,
+                name: name,
+                token: token
+            )))
         }
 
-        return infos
+        return items
     }
     
     @MainActor
@@ -200,12 +219,32 @@ struct OnboardingStep3: View {
     }
 }
 
-struct AppInfo: Identifiable {
+enum SelectionItem: Identifiable {
+    case app(AppInfo)
+    case category(CategoryInfo)
+    
+    var id: String {
+        switch self {
+        case .app(let appInfo):
+            return appInfo.id
+        case .category(let categoryInfo):
+            return categoryInfo.id
+        }
+    }
+}
+
+struct AppInfo {
     let id: String
     let name: String
     let icon: UIImage
     let color: Color
     let token: ApplicationToken
+}
+
+struct CategoryInfo {
+    let id: String
+    let name: String
+    let token: ActivityCategoryToken
 }
 
 struct AppRow: View {
@@ -224,6 +263,38 @@ struct AppRow: View {
             VStack(alignment: .leading, spacing: 4) {
                 Label(appInfo.token)
                     .labelStyle(.titleOnly)
+                    .font(.system(size: 19, weight: .semibold))
+                    .foregroundColor(Color(hex: "1D1D1F"))
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                    .frame(maxWidth: 240, alignment: .leading)
+            }
+
+            Spacer()
+        }
+        .padding(.vertical, 14)
+    }
+}
+
+struct CategoryRow: View {
+    let categoryInfo: CategoryInfo
+
+    var body: some View {
+        HStack(spacing: 16) {
+            ZStack {
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .fill(Color(hex: "E5E5E5"))
+                    .frame(width: 64, height: 64)
+                    .shadow(color: Color.black.opacity(0.05), radius: 4, x: 0, y: 2)
+                
+                Label(categoryInfo.token)
+                    .labelStyle(.iconOnly)
+                    .font(.system(size: 32))
+                    .foregroundColor(Color(hex: "1C1C1E"))
+            }
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(categoryInfo.name)
                     .font(.system(size: 19, weight: .semibold))
                     .foregroundColor(Color(hex: "1D1D1F"))
                     .lineLimit(1)

--- a/Focca/Views/Onboarding/OnboardingStep3.swift
+++ b/Focca/Views/Onboarding/OnboardingStep3.swift
@@ -92,7 +92,7 @@ struct OnboardingStep3: View {
                             }
                             .frame(maxWidth: .infinity)
                             .frame(height: 50)
-                            .background((appInfos.isEmpty || appInfos.count > 50 || isRequestingNotification) ? Color(hex: "DAD7D6") : Color.black)
+                            .background((appInfos.isEmpty || appInfos.count > 50 || isRequestingNotification) ? Color.black.opacity(0.15) : Color.black)
                             .cornerRadius(12)
                             .contentShape(Rectangle())
                         }
@@ -181,12 +181,9 @@ struct OnboardingStep3: View {
         
         // Adiciona categorias
         for token in selection.categoryTokens {
-            let category = ActivityCategory(token: token)
-            let name = category.localizedDisplayName ?? "Categoria"
-            
             items.append(.category(CategoryInfo(
                 id: token.hashValue.description,
-                name: name,
+                name: "", // Nome será obtido via Label no CategoryRow
                 token: token
             )))
         }
@@ -281,20 +278,17 @@ struct CategoryRow: View {
 
     var body: some View {
         HStack(spacing: 16) {
-            ZStack {
-                RoundedRectangle(cornerRadius: 16, style: .continuous)
-                    .fill(Color(hex: "E5E5E5"))
-                    .frame(width: 64, height: 64)
-                    .shadow(color: Color.black.opacity(0.05), radius: 4, x: 0, y: 2)
-                
-                Label(categoryInfo.token)
-                    .labelStyle(.iconOnly)
-                    .font(.system(size: 32))
-                    .foregroundColor(Color(hex: "1C1C1E"))
-            }
+            Label(categoryInfo.token)
+                .labelStyle(.iconOnly)
+                .frame(width: 96, height: 96)
+                .scaleEffect(2.8)
+                .frame(width: 64, height: 64)
+                .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+                .shadow(color: Color.black.opacity(0.05), radius: 4, x: 0, y: 2)
 
             VStack(alignment: .leading, spacing: 4) {
-                Text(categoryInfo.name)
+                Label(categoryInfo.token)
+                    .labelStyle(.titleOnly)
                     .font(.system(size: 19, weight: .semibold))
                     .foregroundColor(Color(hex: "1D1D1F"))
                     .lineLimit(1)

--- a/Focca/Views/Onboarding/OnboardingStep4.swift
+++ b/Focca/Views/Onboarding/OnboardingStep4.swift
@@ -125,7 +125,7 @@ struct OnboardingStep4: View {
                                     }
                                     .frame(maxWidth: .infinity)
                                     .frame(height: 56)
-                                    .background(isValidEmail && !authViewModel.isLoading ? Color(hex: "1D1D1F") : Color(hex: "DAD7D6"))
+                                    .background(isValidEmail && !authViewModel.isLoading ? Color(hex: "1D1D1F") : Color.black.opacity(0.15))
                                     .cornerRadius(12)
                                 }
                                 .contentShape(Rectangle())

--- a/Focca/Views/Onboarding/OnboardingStep5.swift
+++ b/Focca/Views/Onboarding/OnboardingStep5.swift
@@ -88,7 +88,7 @@ struct OnboardingStep5: View {
                                     .foregroundColor(Color(hex: "1D1D1F"))
                                     .frame(maxWidth: .infinity)
                                     .frame(height: 50)
-                                    .background(Color(hex: "E5E5E5"))
+                                    .background(Color.black.opacity(0.1))
                                     .cornerRadius(12)
                             }
                             .disabled(authViewModel.isLoading || resendCount >= 2)
@@ -106,7 +106,7 @@ struct OnboardingStep5: View {
                                         .cornerRadius(12)
                                         .overlay(
                                             RoundedRectangle(cornerRadius: 12)
-                                                .stroke(Color(hex: "E5E5E5"), lineWidth: 1)
+                                                .stroke(Color.black.opacity(0.1), lineWidth: 1)
                                         )
                                 }
                             }
@@ -226,7 +226,7 @@ struct CodeDigitBox: View {
     var body: some View {
         ZStack {
             RoundedRectangle(cornerRadius: 12)
-                .fill(text.isEmpty ? Color(hex: "E5E5E5") : Color.white)
+                .fill(text.isEmpty ? Color.black.opacity(0.1) : Color.white)
                 .overlay(
                     RoundedRectangle(cornerRadius: 12)
                         .stroke(isFocused ? Color(hex: "1D1D1F") : Color.clear, lineWidth: 2)

--- a/Focca/Views/Onboarding/OnboardingStep6.swift
+++ b/Focca/Views/Onboarding/OnboardingStep6.swift
@@ -39,10 +39,25 @@ struct OnboardingStep6: View {
                 Button(action: {
                     if let data = UserDefaults.standard.data(forKey: "familyActivitySelection"),
                        let saved = try? JSONDecoder().decode(FamilyActivitySelection.self, from: data),
-                       saved.applicationTokens.count > 0 {
+                       (saved.applicationTokens.count > 0 || saved.categoryTokens.count > 0 || saved.webDomainTokens.count > 0) {
                         let store = ManagedSettingsStore()
-                        let apps = Set(saved.applicationTokens.compactMap { Application(token: $0) })
-                        store.application.blockedApplications = apps
+
+                        // Bloqueia apps individuais
+                        if !saved.applicationTokens.isEmpty {
+                            let apps = Set(saved.applicationTokens.compactMap { Application(token: $0) })
+                            store.application.blockedApplications = apps
+                        }
+
+                        // Bloqueia categorias de apps
+                        if !saved.categoryTokens.isEmpty {
+                            store.shield.applicationCategories = .specific(saved.categoryTokens)
+                        }
+
+                        // Bloqueia domínios web
+                        if !saved.webDomainTokens.isEmpty {
+                            let domains = Set(saved.webDomainTokens.compactMap { WebDomain(token: $0) })
+                            store.webContent.blockedByFilter = .specific(domains)
+                        }
 
                         if UserDefaults.standard.bool(forKey: "mode_default_exists") == false {
                             UserDefaults.standard.set(true, forKey: "mode_default_exists")
@@ -51,7 +66,8 @@ struct OnboardingStep6: View {
                             }
                         }
                         UserDefaults.standard.set("padrão", forKey: "active_mode_name")
-                        UserDefaults.standard.set(saved.applicationTokens.count, forKey: "active_mode_app_count")
+                        let totalCount = saved.applicationTokens.count + saved.categoryTokens.count + saved.webDomainTokens.count
+                        UserDefaults.standard.set(totalCount, forKey: "active_mode_app_count")
 
                         let now = Date()
                         sharedDefaults.set(now, forKey: "blocked_start_date")

--- a/Focca/Views/Schedule/ScheduleManager.swift
+++ b/Focca/Views/Schedule/ScheduleManager.swift
@@ -363,13 +363,29 @@ class ScheduleManager: ObservableObject {
             return
         }
         
-        print("   ✅ Modo '\(schedule.modeName)' encontrado com \(saved.applicationTokens.count) apps")
-        
+        print("   ✅ Modo '\(schedule.modeName)' encontrado com \(saved.applicationTokens.count) apps, \(saved.categoryTokens.count) categorias, \(saved.webDomainTokens.count) sites")
+
         let store = ManagedSettingsStore()
-        let apps = Set(saved.applicationTokens.compactMap { Application(token: $0) })
-        store.application.blockedApplications = apps
-        
-        print("   ✅ Apps bloqueados: \(apps.count)")
+
+        // Bloqueia apps individuais
+        if !saved.applicationTokens.isEmpty {
+            let apps = Set(saved.applicationTokens.compactMap { Application(token: $0) })
+            store.application.blockedApplications = apps
+            print("   ✅ Apps bloqueados: \(apps.count)")
+        }
+
+        // Bloqueia categorias de apps
+        if !saved.categoryTokens.isEmpty {
+            store.shield.applicationCategories = .specific(saved.categoryTokens)
+            print("   ✅ Categorias bloqueadas: \(saved.categoryTokens.count)")
+        }
+
+        // Bloqueia domínios web
+        if !saved.webDomainTokens.isEmpty {
+            let domains = Set(saved.webDomainTokens.compactMap { WebDomain(token: $0) })
+            store.webContent.blockedByFilter = .specific(domains)
+            print("   ✅ Sites bloqueados: \(domains.count)")
+        }
         
         // Marca início do bloqueio por schedule
         let now = Date()
@@ -387,7 +403,8 @@ class ScheduleManager: ObservableObject {
         
         userDefaults.set(true, forKey: "blocked_by_schedule")
         userDefaults.set(schedule.modeName, forKey: "active_mode_name")
-        userDefaults.set(saved.applicationTokens.count, forKey: "active_mode_app_count")
+        let totalCount = saved.applicationTokens.count + saved.categoryTokens.count + saved.webDomainTokens.count
+        userDefaults.set(totalCount, forKey: "active_mode_app_count")
         
         // Registra início de bloqueio por app usando a data existente se houver
         // Isso previne criar novas sessões quando o app reinicia
@@ -434,8 +451,10 @@ class ScheduleManager: ObservableObject {
         
         let store = ManagedSettingsStore()
         store.application.blockedApplications = nil
-        
-        print("   ✅ Apps desbloqueados")
+        store.shield.applicationCategories = nil
+        store.webContent.blockedByFilter = nil
+
+        print("   ✅ Apps, categorias e sites desbloqueados")
         
         // Finaliza bloqueio por app
         if let selection = blockedSelection {

--- a/Focca/Views/UnlockedView.swift
+++ b/Focca/Views/UnlockedView.swift
@@ -201,8 +201,23 @@ struct UnlockedView: View {
         if let data = UserDefaults.standard.data(forKey: "mode_\(activeMode)_selection"),
            let saved = try? JSONDecoder().decode(FamilyActivitySelection.self, from: data) {
             let store = ManagedSettingsStore()
-            let apps = Set(saved.applicationTokens.compactMap { Application(token: $0) })
-            store.application.blockedApplications = apps
+
+            // Bloqueia apps individuais
+            if !saved.applicationTokens.isEmpty {
+                let apps = Set(saved.applicationTokens.compactMap { Application(token: $0) })
+                store.application.blockedApplications = apps
+            }
+
+            // Bloqueia categorias de apps
+            if !saved.categoryTokens.isEmpty {
+                store.shield.applicationCategories = .specific(saved.categoryTokens)
+            }
+
+            // Bloqueia domínios web
+            if !saved.webDomainTokens.isEmpty {
+                let domains = Set(saved.webDomainTokens.compactMap { WebDomain(token: $0) })
+                store.webContent.blockedByFilter = .specific(domains)
+            }
             
             let now = Date()
             sharedDefaults.set(now, forKey: "blocked_start_date")
@@ -253,7 +268,8 @@ struct UnlockedView: View {
 
                 if let data = UserDefaults.standard.data(forKey: "mode_\(modeName)_selection"),
                    let saved = try? JSONDecoder().decode(FamilyActivitySelection.self, from: data) {
-                    UserDefaults.standard.set(saved.applicationTokens.count, forKey: "active_mode_app_count")
+                    let totalCount = saved.applicationTokens.count + saved.categoryTokens.count + saved.webDomainTokens.count
+                    UserDefaults.standard.set(totalCount, forKey: "active_mode_app_count")
                 }
 
                 return modeName


### PR DESCRIPTION
## Descrição

  Corrige o bug onde a seleção de categorias inteiras (ex: Entretenimento, Jogos) não funcionava. Agora o
  usuário pode escolher categorias completas sem precisar selecionar apps um por um.

  ## O que mudou

  - ✅ Seleção de categorias agora funciona corretamente
  - ✅ Mostra contagem de categorias, apps e sites selecionados
  - ✅ Bloqueia todos os apps da categoria escolhida
  - ✅ Suporte para bloquear domínios web também

  ## Como testar

  1. Abra o onboarding ou edite um modo
  2. Selecione uma categoria inteira (ex: Entretenimento)
  3. Ative o bloqueio
  4. Todos os apps da categoria devem ser bloqueados
  
  Restrição: Infelizmente para categorias é permitido apeans a função de shield

  Closes #3