### PR TITLE
fix: remove non-functional app icon attachment code from notifications

### DIFF
--- a/Focca/Core/Notifications/NotificationContent.swift
+++ b/Focca/Core/Notifications/NotificationContent.swift
@@ -9,78 +9,22 @@ struct NotificationContent {
     /// - Returns: Conteúdo configurado seguindo as melhores práticas da Apple
     static func createScheduleNotification(for schedule: ScheduleModel) -> UNMutableNotificationContent {
         let content = UNMutableNotificationContent()
-        
+
         // Título claro e conciso (melhor prática Apple)
         content.title = "Agendamento Começando em Breve"
-        
+
         // Mensagem personalizada com o nome do modo
         content.body = "Seu agendamento '\(schedule.modeName)' começa em 10 minutos"
-        
+
         // Som padrão do sistema
         content.sound = .default
-        
+
         // Badge atualizado
         content.badge = 1
-        
+
         // Categoria para possíveis ações (abrir app / iniciar agora)
         content.categoryIdentifier = "SCHEDULE_REMINDER"
-        
-        // Adiciona o ícone do app (thumbnail)
-        // iOS não permite attachments muito pequenos, então vamos usar uma imagem maior
-        // Tenta obter o ícone do app de diferentes formas
-        var appIconImage: UIImage? = nil
-        
-        // Método 1: Tenta carregar do bundle principal
-        if let icon = UIImage(named: "AppIcon") {
-            appIconImage = icon
-        } else if let icon = UIImage(named: "AppIcon-1024") {
-            appIconImage = icon
-        } else if let iconPath = Bundle.main.path(forResource: "AppIcon", ofType: "png"),
-                  let icon = UIImage(contentsOfFile: iconPath) {
-            appIconImage = icon
-        } else {
-            // Método 2: Tenta obter do Info.plist
-            if let icons = Bundle.main.infoDictionary?["CFBundleIcons"] as? [String: Any],
-               let primaryIcon = icons["CFBundlePrimaryIcon"] as? [String: Any],
-               let iconFiles = primaryIcon["CFBundleIconFiles"] as? [String],
-               let lastIcon = iconFiles.last,
-               let icon = UIImage(named: lastIcon) {
-                appIconImage = icon
-            }
-        }
-        
-        // Para notificações, o iOS requer imagens maiores (mínimo 300x300px)
-        // Redimensiona o ícone se necessário
-        if let appIcon = appIconImage {
-            let minSize: CGFloat = 300
-            let resizedIcon: UIImage
-            
-            if appIcon.size.width < minSize || appIcon.size.height < minSize {
-                // Redimensiona para pelo menos 300x300
-                let scale = max(minSize / appIcon.size.width, minSize / appIcon.size.height)
-                let newSize = CGSize(width: appIcon.size.width * scale, height: appIcon.size.height * scale)
-                
-                UIGraphicsBeginImageContextWithOptions(newSize, false, 0.0)
-                appIcon.draw(in: CGRect(origin: .zero, size: newSize))
-                resizedIcon = UIGraphicsGetImageFromCurrentImageContext() ?? appIcon
-                UIGraphicsEndImageContext()
-            } else {
-                resizedIcon = appIcon
-            }
-            
-            if let imageURL = saveImageToTempDirectory(resizedIcon) {
-                if let attachment = try? UNNotificationAttachment(
-                    identifier: "appIcon",
-                    url: imageURL,
-                    options: [
-                        UNNotificationAttachmentOptionsTypeHintKey: "public.png"
-                    ]
-                ) {
-                    content.attachments = [attachment]
-                }
-            }
-        }
-        
+
         return content
     }
 
@@ -104,24 +48,6 @@ struct NotificationContent {
         ]
         
         return content
-    }
-    
-    /// Helper para salvar imagem em diretório temporário para usar como attachment
-    private static func saveImageToTempDirectory(_ image: UIImage) -> URL? {
-        let tempDir = FileManager.default.temporaryDirectory
-        let imageURL = tempDir.appendingPathComponent("appIcon_\(UUID().uuidString).png")
-        
-        guard let imageData = image.pngData() else {
-            return nil
-        }
-        
-        do {
-            try imageData.write(to: imageURL)
-            return imageURL
-        } catch {
-            print("❌ Erro ao salvar imagem temporária: \(error.localizedDescription)")
-            return nil
-        }
     }
 }
 

--- a/Focca/Core/Notifications/NotificationManager.swift
+++ b/Focca/Core/Notifications/NotificationManager.swift
@@ -150,40 +150,5 @@ class NotificationManager {
         }
     }
 
-    // MARK: - Debug/Testing
-
-    /// Envia uma notificação de teste em 5 segundos para debug
-    /// Use este método para testar rapidamente as notificações durante desenvolvimento
-    func sendTestNotification() {
-        Task {
-            let status = await checkAuthorizationStatus()
-            await MainActor.run {
-                guard status == .authorized else {
-                    print("❌ Notificações não autorizadas. Solicite permissão primeiro.")
-                    return
-                }
-
-                let content = UNMutableNotificationContent()
-                content.title = "🧪 Teste de Notificação"
-                content.body = "Esta é uma notificação de teste do Focca. O ícone do app deve aparecer automaticamente."
-                content.sound = .default
-                content.badge = 1
-                content.categoryIdentifier = "SCHEDULE_REMINDER"
-
-                let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 5, repeats: false)
-                let identifier = "test_notification_\(Date().timeIntervalSince1970)"
-                let request = UNNotificationRequest(identifier: identifier, content: content, trigger: trigger)
-
-                UNUserNotificationCenter.current().add(request) { error in
-                    if let error = error {
-                        print("❌ Erro ao agendar notificação de teste: \(error.localizedDescription)")
-                    } else {
-                        print("✅ Notificação de teste agendada para 5 segundos")
-                        print("💡 Minimize o app ou bloqueie o dispositivo para ver a notificação")
-                    }
-                }
-            }
-        }
-    }
 }
 

--- a/Focca/Core/Notifications/NotificationManager.swift
+++ b/Focca/Core/Notifications/NotificationManager.swift
@@ -40,64 +40,7 @@ class NotificationManager {
             content.sound = .default
             content.badge = 1
             content.categoryIdentifier = "SCHEDULE_REMINDER"
-            
-            // Adiciona o ícone do app
-            var appIconImage: UIImage? = nil
-            
-            // Tenta obter o ícone do app de diferentes formas
-            if let icon = UIImage(named: "AppIcon") {
-                appIconImage = icon
-            } else if let icon = UIImage(named: "AppIcon-1024") {
-                appIconImage = icon
-            } else if let iconPath = Bundle.main.path(forResource: "AppIcon", ofType: "png"),
-                      let icon = UIImage(contentsOfFile: iconPath) {
-                appIconImage = icon
-            } else {
-                // Tenta obter do Info.plist
-                if let icons = Bundle.main.infoDictionary?["CFBundleIcons"] as? [String: Any],
-                   let primaryIcon = icons["CFBundlePrimaryIcon"] as? [String: Any],
-                   let iconFiles = primaryIcon["CFBundleIconFiles"] as? [String],
-                   let lastIcon = iconFiles.last,
-                   let icon = UIImage(named: lastIcon) {
-                    appIconImage = icon
-                }
-            }
-            
-            // Para notificações, o iOS requer imagens maiores (mínimo 300x300px)
-            // Redimensiona o ícone se necessário
-            if let appIcon = appIconImage {
-                let minSize: CGFloat = 300
-                let resizedIcon: UIImage
-                
-                if appIcon.size.width < minSize || appIcon.size.height < minSize {
-                    // Redimensiona para pelo menos 300x300
-                    let scale = max(minSize / appIcon.size.width, minSize / appIcon.size.height)
-                    let newSize = CGSize(width: appIcon.size.width * scale, height: appIcon.size.height * scale)
-                    
-                    UIGraphicsBeginImageContextWithOptions(newSize, false, 0.0)
-                    appIcon.draw(in: CGRect(origin: .zero, size: newSize))
-                    resizedIcon = UIGraphicsGetImageFromCurrentImageContext() ?? appIcon
-                    UIGraphicsEndImageContext()
-                } else {
-                    resizedIcon = appIcon
-                }
-                
-                let tempDir = FileManager.default.temporaryDirectory
-                let imageURL = tempDir.appendingPathComponent("appIcon_3min_\(UUID().uuidString).png")
-                if let imageData = resizedIcon.pngData() {
-                    try? imageData.write(to: imageURL)
-                    if let attachment = try? UNNotificationAttachment(
-                        identifier: "appIcon",
-                        url: imageURL,
-                        options: [
-                            UNNotificationAttachmentOptionsTypeHintKey: "public.png"
-                        ]
-                    ) {
-                        content.attachments = [attachment]
-                    }
-                }
-            }
-            
+
             // Trigger para 3 minutos
             let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 180, repeats: false)
             let identifier = "schedule_\(schedule.id)_3min_\(Date().timeIntervalSince1970)"
@@ -203,6 +146,42 @@ class NotificationManager {
                 let identifier = "info_\(Date().timeIntervalSince1970)"
                 let request = UNNotificationRequest(identifier: identifier, content: content, trigger: trigger)
                 UNUserNotificationCenter.current().add(request) { _ in }
+            }
+        }
+    }
+
+    // MARK: - Debug/Testing
+
+    /// Envia uma notificação de teste em 5 segundos para debug
+    /// Use este método para testar rapidamente as notificações durante desenvolvimento
+    func sendTestNotification() {
+        Task {
+            let status = await checkAuthorizationStatus()
+            await MainActor.run {
+                guard status == .authorized else {
+                    print("❌ Notificações não autorizadas. Solicite permissão primeiro.")
+                    return
+                }
+
+                let content = UNMutableNotificationContent()
+                content.title = "🧪 Teste de Notificação"
+                content.body = "Esta é uma notificação de teste do Focca. O ícone do app deve aparecer automaticamente."
+                content.sound = .default
+                content.badge = 1
+                content.categoryIdentifier = "SCHEDULE_REMINDER"
+
+                let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 5, repeats: false)
+                let identifier = "test_notification_\(Date().timeIntervalSince1970)"
+                let request = UNNotificationRequest(identifier: identifier, content: content, trigger: trigger)
+
+                UNUserNotificationCenter.current().add(request) { error in
+                    if let error = error {
+                        print("❌ Erro ao agendar notificação de teste: \(error.localizedDescription)")
+                    } else {
+                        print("✅ Notificação de teste agendada para 5 segundos")
+                        print("💡 Minimize o app ou bloqueie o dispositivo para ver a notificação")
+                    }
+                }
             }
         }
     }

--- a/Focca/Views/Settings/SettingsView.swift
+++ b/Focca/Views/Settings/SettingsView.swift
@@ -105,19 +105,6 @@ struct SettingsView: View {
                         isBlocked: isBlocked
                     )
 
-                    // Debug section
-                    #if DEBUG
-                    SettingsSection(
-                        title: "Debug",
-                        items: [
-                            SettingsItem(title: "Testar Notificação (5s)", hasArrow: true, action: .testNotification)
-                        ],
-                        showNotificationsView: $showNotificationsView,
-                        selectedTab: $selectedTab,
-                        isBlocked: isBlocked
-                    )
-                    #endif
-
                 }
                 .padding(.horizontal, 16)
                 
@@ -220,8 +207,6 @@ struct SettingsRow: View {
                     break
                 case .goalsToggle:
                     break
-                case .testNotification:
-                    NotificationManager.shared.sendTestNotification()
                 case .none:
                     break
                 }
@@ -325,7 +310,6 @@ enum SettingsAction {
     case goalsToggle
     case advancedStats
     case friends
-    case testNotification
 }
 
 struct SettingsItem {

--- a/Focca/Views/Settings/SettingsView.swift
+++ b/Focca/Views/Settings/SettingsView.swift
@@ -104,7 +104,20 @@ struct SettingsView: View {
                         selectedTab: $selectedTab,
                         isBlocked: isBlocked
                     )
-                    
+
+                    // Debug section
+                    #if DEBUG
+                    SettingsSection(
+                        title: "Debug",
+                        items: [
+                            SettingsItem(title: "Testar Notificação (5s)", hasArrow: true, action: .testNotification)
+                        ],
+                        showNotificationsView: $showNotificationsView,
+                        selectedTab: $selectedTab,
+                        isBlocked: isBlocked
+                    )
+                    #endif
+
                 }
                 .padding(.horizontal, 16)
                 
@@ -207,6 +220,8 @@ struct SettingsRow: View {
                     break
                 case .goalsToggle:
                     break
+                case .testNotification:
+                    NotificationManager.shared.sendTestNotification()
                 case .none:
                     break
                 }
@@ -310,6 +325,7 @@ enum SettingsAction {
     case goalsToggle
     case advancedStats
     case friends
+    case testNotification
 }
 
 struct SettingsItem {


### PR DESCRIPTION
  Código tentava adicionar ícone do app via attachments, mas iOS já fornece isso automaticamente do Asset
  Catalog.

  Mudanças

  - Remove ~70 linhas de código não funcional
  - Adiciona método de teste sendTestNotification()
  - Adiciona botão "Testar Notificação (5s)" em Settings (DEBUG only)

  Como Testar

  Settings → Debug → Testar Notificação → minimizar app → verificar ícone aparece
  obs: essa config de simular push só aparece em debug, ao lançar não aparece

  Closes #15
  
  
<img width="428" height="294" alt="image" src="https://github.com/user-attachments/assets/9a2ca98f-d166-4665-b06a-3c35a4a9f137" />
<img width="428" height="292" alt="image" src="https://github.com/user-attachments/assets/c0166f0a-26a3-431d-a57e-ab97c99ba667" />
